### PR TITLE
Including arrhythmia page back in diagnostics depart

### DIFF
--- a/views/pages/diagnostic-depart.ejs
+++ b/views/pages/diagnostic-depart.ejs
@@ -97,6 +97,23 @@
                                 <button class="button" onclick="document.location='Breast-Diagnostic'">Learn More</button>
                             </div>
                         </div>
+
+			<div class="card swiper-slide">
+                            <div class="image-content">
+                                
+
+                                <div class="card-image">
+                                    <img src="images/ecg_ml.jpg" class="card-img">
+                                </div>
+                            </div>
+
+                            <div class="card-content">
+                                <h2 class="name">Arrhythmia Diagnostics</h2>
+                                <p class="description">Here is the page for arrhythmia diagnostics.</p>
+
+                                <button class="button" onclick="document.location='ecg-ml'">Learn More</button>
+                            </div>
+                        </div>
                         <div class="card swiper-slide">
                             <div class="image-content">
                                 


### PR DESCRIPTION
Hi,
Please include the following changes:
- Added a card with arrhythmia diagnostics to the diagnostics depart page (someone deleted this in a previous commit and our tool wasn't displayed anymore with the other ones).

Thanks!