### PR TITLE
Improved error handling on Contact Us page.

### DIFF
--- a/index.js
+++ b/index.js
@@ -375,19 +375,22 @@ app.get('/heartDiseasePrediction', (req, res) => {
 app.get('/lab', (req, res) => {
   res.render("pages/lab");
 })
+
+
+/* TaskName - Contact Us page with email confirmation 
+   Team: Apeksha, Enrico, Tarin
+*/
 app.get('/contact-us', (req, res) => {
   res.render("pages/contact-us");
 });
 
 app.post('/send-contact-form', (req, res) => {
-
-
   const SENDER_EMAIL = "ehospital23@gmail.com";
   const SENDER_PASS = "bozsyftcnmqhokte";
+  
   const RECEIVER_NAME = req.body.userName;
   const RECEIVER_EMAIL = req.body.userEmail;
-
-  const USER_PHONE = req.body.phoneNumber;
+  const PHONE_NUMBER = req.body.phoneNumber;
   const USER_MESSAGE = req.body.userMessage;
 
   let VALID_INPUTS = true;
@@ -402,11 +405,20 @@ app.post('/send-contact-form', (req, res) => {
     console.log(sql);
     conn.query(sql, (error, result) => {
       if (error) {
-        res.send({ error: error.sqlMessage });
+        res.send(`
+        <script>alert("An error occured while sending. Error message: ${error.sqlMessage}"); 
+          window.location.href = "/contact-us";
+        </script>`
+        );
+        
         return;
       }
       if (result.affectedRows != 1) {
-        res.send({ error: "Something goes wrong in the database." });
+        res.send(`
+        <script>alert("Sorry, an error occured in the database. Please contact the site admin."); 
+          window.location.href = "/contact-us";
+        </script>`
+        );
         return;
       }
     })
@@ -424,7 +436,7 @@ app.post('/send-contact-form', (req, res) => {
       <br>
       <p> Name: ${RECEIVER_NAME} </p>
       <p> Email: ${RECEIVER_EMAIL} </p>
-      <p> Phone: ${USER_PHONE} </p>
+      <p> Phone: ${PHONE_NUMBER} </p>
       <p> Message: ${USER_MESSAGE} </p>
     `;
 
@@ -469,9 +481,9 @@ app.post('/send-contact-form', (req, res) => {
       window.location.href = "/contact-us";
     </script>`
     );
-
   }
 })
+
 
 
 app.post('/Hospital_DashBoard', (req, res) => { // For the Admin Credentials:  (Admin , Admin)

--- a/views/pages/contact-us.ejs
+++ b/views/pages/contact-us.ejs
@@ -2027,7 +2027,7 @@ SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
                               <div data-ux="Block" class="x-el x-el-div c1-1 c1-2 c1-7u c1-b c1-c c1-d c1-e c1-f c1-g">
                                 <div data-ux="Block" class="x-el x-el-div c1-1 c1-2 c1-b c1-c c1-d c1-e c1-f c1-g">
                                   <div data-ux="InputFloatLabel" type="text" data-aid="CONTACT_FORM_NAME" class="x-el x-el-div c1-1 c1-2 c1-3o c1-b c1-c c1-d c1-e c1-f c1-g">
-                                    <input name="userName" placeholder="Your Name" type="text" role="textbox" aria-multiline="false" data-ux="InputFloatLabel" id="input5387" data-aid="CONTACT_FORM_NAME" data-typography="InputAlpha" class="x-el x-el-input c1-1 c1-2 c1-h c1-7v c1-4 c1-7w c1-7x c1-7y c1-7z c1-80 c1-4e c1-4f c1-81 c1-2m c1-57 c1-b c1-82 c1-42 c1-43 c1-83 c1-84 c1-85 c1-86 c1-87 c1-88 c1-89 c1-8a c1-8b c1-8c c1-8d c1-45 c1-46 c1-47 c1-48" />
+                                    <input name="userName" placeholder="Your Name" type="text" role="textbox" aria-multiline="false" data-ux="InputFloatLabel" id="input5387" data-aid="CONTACT_FORM_NAME" data-typography="InputAlpha" required class="x-el x-el-input c1-1 c1-2 c1-h c1-7v c1-4 c1-7w c1-7x c1-7y c1-7z c1-80 c1-4e c1-4f c1-81 c1-2m c1-57 c1-b c1-82 c1-42 c1-43 c1-83 c1-84 c1-85 c1-86 c1-87 c1-88 c1-89 c1-8a c1-8b c1-8c c1-8d c1-45 c1-46 c1-47 c1-48" />
                                     <label data-ux="InputFloatLabelLabel" for="input5387" data-typography="InputAlpha" class="x-el x-el-label c1-1 c1-2 c1-1o c1-1b c1-1c c1-4g c1-8e c1-8f c1-8g c1-8h c1-b c1-82 c1-42 c1-43 c1-8d c1-45 c1-46 c1-47 c1-48">
                                       Name*
                                     </label>
@@ -2037,7 +2037,7 @@ SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
                               <div data-ux="Block" class="x-el x-el-div c1-1 c1-2 c1-7u c1-b c1-c c1-d c1-e c1-f c1-g">
                                 <div data-ux="Block" class="x-el x-el-div c1-1 c1-2 c1-b c1-c c1-d c1-e c1-f c1-g">
                                   <div data-ux="InputFloatLabel" type="text" data-aid="CONTACT_FORM_EMAIL" class="x-el x-el-div c1-1 c1-2 c1-3o c1-b c1-c c1-d c1-e c1-f c1-g">
-                                    <input name="userEmail" type="text" role="textbox" aria-multiline="false" data-ux="InputFloatLabel" id="input5388" placeholder="Your Email" data-aid="CONTACT_FORM_EMAIL" data-typography="InputAlpha" class="x-el x-el-input c1-1 c1-2 c1-h c1-7v c1-4 c1-7w c1-7x c1-7y c1-7z c1-80 c1-4e c1-4f c1-81 c1-2m c1-57 c1-b c1-82 c1-42 c1-43 c1-83 c1-84 c1-85 c1-86 c1-87 c1-88 c1-89 c1-8a c1-8b c1-8c c1-8d c1-45 c1-46 c1-47 c1-48" />
+                                    <input name="userEmail" type="text" role="textbox" aria-multiline="false" data-ux="InputFloatLabel" id="input5388" placeholder="Your Email" data-aid="CONTACT_FORM_EMAIL" data-typography="InputAlpha" required class="x-el x-el-input c1-1 c1-2 c1-h c1-7v c1-4 c1-7w c1-7x c1-7y c1-7z c1-80 c1-4e c1-4f c1-81 c1-2m c1-57 c1-b c1-82 c1-42 c1-43 c1-83 c1-84 c1-85 c1-86 c1-87 c1-88 c1-89 c1-8a c1-8b c1-8c c1-8d c1-45 c1-46 c1-47 c1-48" />
                                     <label data-ux="InputFloatLabelLabel" for="input5388" data-typography="InputAlpha" class="x-el x-el-label c1-1 c1-2 c1-1o c1-1b c1-1c c1-4g c1-8e c1-8f c1-8g c1-8h c1-b c1-82 c1-42 c1-43 c1-8d c1-45 c1-46 c1-47 c1-48">
                                       Email*
                                     </label>
@@ -2048,7 +2048,7 @@ SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
                               <div data-ux="Block" class="x-el x-el-div c1-1 c1-2 c1-7u c1-b c1-c c1-d c1-e c1-f c1-g">
                                 <div data-ux="Block" class="x-el x-el-div c1-1 c1-2 c1-b c1-c c1-d c1-e c1-f c1-g">
                                   <div data-ux="InputFloatLabel" type="text" data-aid="CONTACT_FORM_EMAIL" class="x-el x-el-div c1-1 c1-2 c1-3o c1-b c1-c c1-d c1-e c1-f c1-g">
-                                    <input name="phoneNumber" type="tel" role="textbox" aria-multiline="false" data-ux="InputFloatLabel" id="input5388" placeholder="Your Phone Number" data-aid="CONTACT_FORM_NUMBER" data-typography="InputAlpha" class="x-el x-el-input c1-1 c1-2 c1-h c1-7v c1-4 c1-7w c1-7x c1-7y c1-7z c1-80 c1-4e c1-4f c1-81 c1-2m c1-57 c1-b c1-82 c1-42 c1-43 c1-83 c1-84 c1-85 c1-86 c1-87 c1-88 c1-89 c1-8a c1-8b c1-8c c1-8d c1-45 c1-46 c1-47 c1-48" />
+                                    <input name="phoneNumber" type="tel" role="textbox" aria-multiline="false" data-ux="InputFloatLabel" id="input5388" placeholder="Your Phone Number" data-aid="CONTACT_FORM_NUMBER" data-typography="InputAlpha" required class="x-el x-el-input c1-1 c1-2 c1-h c1-7v c1-4 c1-7w c1-7x c1-7y c1-7z c1-80 c1-4e c1-4f c1-81 c1-2m c1-57 c1-b c1-82 c1-42 c1-43 c1-83 c1-84 c1-85 c1-86 c1-87 c1-88 c1-89 c1-8a c1-8b c1-8c c1-8d c1-45 c1-46 c1-47 c1-48" />
                                     <label data-ux="InputFloatLabelLabel" for="input5388" data-typography="InputAlpha" class="x-el x-el-label c1-1 c1-2 c1-1o c1-1b c1-1c c1-4g c1-8e c1-8f c1-8g c1-8h c1-b c1-82 c1-42 c1-43 c1-8d c1-45 c1-46 c1-47 c1-48">
                                       Phone*
                                     </label>
@@ -2058,7 +2058,7 @@ SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
 
                               <div data-ux="Block" class="x-el x-el-div c1-1 c1-2 c1-7u c1-b c1-c c1-d c1-e c1-f c1-g">
                                 <div data-ux="Block" class="x-el x-el-div c1-1 c1-2 c1-b c1-c c1-d c1-e c1-f c1-g">
-                                  <textarea name="userMessage" type="text" role="textbox" aria-multiline="true" rows="5" aria-label="Message" data-ux="InputTextArea" placeholder="Message" data-aid="CONTACT_FORM_MESSAGE" data-typography="InputAlpha" class="x-el x-el-textarea c1-1 c1-2 c1-h c1-7v c1-4 c1-7w c1-7x c1-7y c1-7z c1-v c1-4e c1-4f c1-u c1-2m c1-57 c1-8i c1-b c1-82 c1-42 c1-43 c1-83 c1-84 c1-85 c1-8c c1-8d c1-45 c1-46 c1-47 c1-48"></textarea>
+                                  <textarea name="userMessage" type="text" role="textbox" aria-multiline="true" rows="5" aria-label="Message" data-ux="InputTextArea" required placeholder="Message" data-aid="CONTACT_FORM_MESSAGE" data-typography="InputAlpha" class="x-el x-el-textarea c1-1 c1-2 c1-h c1-7v c1-4 c1-7w c1-7x c1-7y c1-7z c1-v c1-4e c1-4f c1-u c1-2m c1-57 c1-8i c1-b c1-82 c1-42 c1-43 c1-83 c1-84 c1-85 c1-8c c1-8d c1-45 c1-46 c1-47 c1-48"></textarea>
                                 </div>
                               </div>
                               <div data-ux="Block" class="x-el x-el-div c1-1 c1-2 c1-7u c1-b c1-c c1-d c1-e c1-f c1-g">


### PR DESCRIPTION
Change error handling on Contact-Us page so it alerts and then redirects user back to the original page instead of showing a random page with just the error message in plaintext.

This PR also adds the "required" flag for the form inputs as this was missing.
